### PR TITLE
Type extension flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,12 @@ massimo <url> --name myclient --module cjs  # In CommonJS project → .d.ts
 massimo <url> --name myclient --module esm  # In CommonJS project → .d.mts
 massimo <url> --name myclient --module cjs  # In ESM project → .d.cts
 
-# Auto-detect everything (no module flag) → always .d.ts
+# Auto-detect everything (no module flag) → always .d.ts  
 massimo <url> --name myclient  # → .d.ts (maximum compatibility)
+
+# Explicit module generates module-specific when no parent package.json
+massimo <url> --name myclient --module esm  # No parent pkg → .d.mts
+massimo <url> --name myclient --module cjs  # No parent pkg → .d.cts
 ```
 
 ### Client Options

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ massimo <url> --name myclient --folder ./clients
 # Specify module format (valid values: esm, cjs)
 massimo <url> --name myclient --module esm
 massimo <url> --name myclient --module cjs
+
+# Force TypeScript declaration file extensions (.d.mts/.d.cts)
+massimo <url> --name myclient --type-extension
 ```
 
 ### Module Format Detection
@@ -255,6 +258,49 @@ This overrides any auto-detection and generates files in the specified format.
 |--------------|----------------|--------|--------------|
 | **ESM** | `.mjs` | `.d.mts` | `"type": "module"` |
 | **CommonJS** | `.cjs` | `.d.cts` | No `"type"` field |
+
+### TypeScript Declaration File Extensions
+
+Massimo uses intelligent logic to determine the appropriate TypeScript declaration file extension (`.d.ts`, `.d.mts`, or `.d.cts`):
+
+#### **Type Extension Determination Rules**
+
+1. **When `--type-extension` is specified**:
+   - Always generates module-specific extensions
+   - ESM format → `.d.mts`
+   - CommonJS format → `.d.cts`
+
+2. **When `--type-extension` is NOT specified**:
+   - If `--module` flag is provided:
+     - Compares the specified module format with the parent package.json type
+     - If they match → generates `.d.ts` (universal compatibility)
+     - If they differ → generates module-specific extension (`.d.mts` or `.d.cts`)
+   - If no `--module` flag is provided:
+     - Always generates `.d.ts` for maximum compatibility
+
+3. **Parent Package.json Detection**:
+   - Searches up the directory tree from the output location
+   - Stops at the first package.json found
+   - ESM parent: `"type": "module"`
+   - CommonJS parent: no `type` field or `"type": "commonjs"`
+
+#### **Examples**
+
+```bash
+# Always use module-specific extensions
+massimo <url> --name myclient --type-extension
+
+# Generate .d.ts when module format matches parent package.json
+massimo <url> --name myclient --module esm  # In ESM project → .d.ts
+massimo <url> --name myclient --module cjs  # In CommonJS project → .d.ts
+
+# Generate module-specific when formats differ
+massimo <url> --name myclient --module esm  # In CommonJS project → .d.mts
+massimo <url> --name myclient --module cjs  # In ESM project → .d.cts
+
+# Auto-detect everything (no module flag) → always .d.ts
+massimo <url> --name myclient  # → .d.ts (maximum compatibility)
+```
 
 ### Client Options
 

--- a/packages/massimo-cli/help/help.txt
+++ b/packages/massimo-cli/help/help.txt
@@ -55,7 +55,7 @@ You can generate only the types with the --types-only flag.
 $ massimo http://exmaple.com/to/schema/file --name myclient --types-only
 ```
 
-Will create the single myclient.d.ts file.
+Will create the single myclient.d.ts file (or .d.mts/.d.cts depending on module format and --type-extension option).
 
 Options:
 
@@ -77,3 +77,4 @@ Options:
 * `--props-optional` - If `true`, properties will be defined as optional unless they're part of the `required` array. By default this option is `true`.
 * `--skip-config-update` - If `true`, it will not update the `platformatic|watt` config found in your repo. By default this option is `true`.
 * `--retry-timeout-ms` - If passed, the HTTP request to get an Open API schema will be retried (reference: https://undici.nodejs.org/#/docs/api/RetryHandler.md)
+* `--type-extension` - Force the use of module-specific type extensions (.d.mts for ESM, .d.cts for CJS) instead of the default logic.

--- a/packages/massimo-cli/index.js
+++ b/packages/massimo-cli/index.js
@@ -79,7 +79,7 @@ export async function determineTypeExtension (folder, moduleFormat, typeExtensio
   }
 
   if (!explicitModuleFormat && generateImplementation) {
-    return moduleFormat === 'esm' ? 'd.mts' : 'd.cts'
+    return 'd.ts'
   }
 
   let currentDir = folder
@@ -101,11 +101,11 @@ export async function determineTypeExtension (folder, moduleFormat, typeExtensio
     currentDir = dirname(currentDir)
   }
 
-  if (moduleFormat === 'cjs') {
-    return 'd.ts'
+  if (explicitModuleFormat) {
+    return moduleFormat === 'esm' ? 'd.mts' : 'd.cts'
   }
 
-  return 'd.mts'
+  return 'd.ts'
 }
 
 async function writeOpenAPIClient (

--- a/packages/massimo-cli/lib/frontend-openapi-generator.js
+++ b/packages/massimo-cli/lib/frontend-openapi-generator.js
@@ -18,7 +18,8 @@ export function processFrontendOpenAPI ({
   fullRequest,
   logger,
   withCredentials,
-  propsOptional
+  propsOptional,
+  typeExt = 'd.mts'
 }) {
   return {
     types: generateTypesFromOpenAPI({ schema, name, fullResponse, fullRequest, propsOptional }),
@@ -29,7 +30,8 @@ export function processFrontendOpenAPI ({
       fullResponse,
       fullRequest,
       logger,
-      withCredentials
+      withCredentials,
+      typeExt
     })
   }
 }
@@ -41,7 +43,8 @@ function generateFrontendImplementationFromOpenAPI ({
   fullResponse,
   fullRequest,
   logger,
-  withCredentials
+  withCredentials,
+  typeExt = 'd.mts'
 }) {
   const camelCaseName = capitalize(camelcase(name))
   const { paths } = schema
@@ -111,13 +114,13 @@ function generateFrontendImplementationFromOpenAPI ({
     writer.write('function sanitizeUrl(url)').block(() => {
       writer.writeLine("if (url.endsWith('/')) { return url.slice(0, -1) } else { return url }")
     })
-    writer.writeLine(`/**  @type {import('./${name}-types.d.mts').${camelCaseName}['setBaseUrl']} */`)
+    writer.writeLine(`/**  @type {import('./${name}-types.${typeExt}').${camelCaseName}['setBaseUrl']} */`)
     writer.writeLine('export const setBaseUrl = (newUrl) => { baseUrl = sanitizeUrl(newUrl) }')
     writer.newLine()
-    writer.writeLine(`/**  @type {import('./${name}-types.d.mts').${camelCaseName}['setDefaultHeaders']} */`)
+    writer.writeLine(`/**  @type {import('./${name}-types.${typeExt}').${camelCaseName}['setDefaultHeaders']} */`)
     writer.writeLine('export const setDefaultHeaders = (headers) => { defaultHeaders = headers }')
     writer.newLine()
-    writer.writeLine(`/**  @type {import('./${name}-types.d.mts').${camelCaseName}['setDefaultFetchParams']} */`)
+    writer.writeLine(`/**  @type {import('./${name}-types.${typeExt}').${camelCaseName}['setDefaultFetchParams']} */`)
     writer.writeLine('export const setDefaultFetchParams = (fetchParams) => { defaultFetchParams = fetchParams }')
     writer.newLine()
     writer.write('function headersToJSON(headers) ').block(() => {
@@ -354,7 +357,7 @@ function generateFrontendImplementationFromOpenAPI ({
       // ```
       //
       writer
-        .writeLine(`/**  @type {import('./${name}-types.d.mts').${camelCaseName}['${operationId}']} */`)
+        .writeLine(`/**  @type {import('./${name}-types.${typeExt}').${camelCaseName}['${operationId}']} */`)
         .write(`export const ${operationId} = async (request) =>`)
         .block(() => {
           writer.write(`return await ${underscoredOperationId}(baseUrl, request)`)

--- a/packages/massimo-cli/test/cli-graphql-variants.test.js
+++ b/packages/massimo-cli/test/cli-graphql-variants.test.js
@@ -107,7 +107,7 @@ test('dashes in name (typescript)', async t => {
 
   const dir = await moveToTmpdir(after)
 
-  await execa('node', [join(import.meta.dirname, '..', 'index.js'), app.url + '/graphql', '--name', 'uncanny-movies'])
+  await execa('node', [join(import.meta.dirname, '..', 'index.js'), app.url + '/graphql', '--name', 'uncanny-movies', '--type-extension'])
 
   const toWrite = `
 import Fastify from 'fastify'

--- a/packages/massimo-cli/test/cli-graphql.test.js
+++ b/packages/massimo-cli/test/cli-graphql.test.js
@@ -107,7 +107,7 @@ test('graphql client generation (typescript)', async t => {
 
   const dir = await moveToTmpdir(after)
 
-  await execa('node', [join(import.meta.dirname, '..', 'index.js'), app.url + '/graphql', '--name', 'movies'])
+  await execa('node', [join(import.meta.dirname, '..', 'index.js'), app.url + '/graphql', '--name', 'movies', '--type-extension'])
 
   const toWrite = `
 import Fastify from 'fastify'
@@ -197,7 +197,7 @@ test('graphql client generation with relations (typescript)', async t => {
 
   const dir = await moveToTmpdir(after)
 
-  await execa('node', [join(import.meta.dirname, '..', 'index.js'), app.url + '/graphql', '--name', 'movies'])
+  await execa('node', [join(import.meta.dirname, '..', 'index.js'), app.url + '/graphql', '--name', 'movies', '--type-extension'])
 
   const toWrite = `
 import Fastify from 'fastify';
@@ -309,7 +309,7 @@ test('graphql client generation (javascript) with slash at the end of the URL', 
 
   const dir = await moveToTmpdir(after)
 
-  await execa('node', [join(import.meta.dirname, '..', 'index.js'), app.url + '/graphql', '--name', 'movies'])
+  await execa('node', [join(import.meta.dirname, '..', 'index.js'), app.url + '/graphql', '--name', 'movies', '--type-extension'])
 
   const toWrite = `
 import Fastify from 'fastify'

--- a/packages/massimo-cli/test/cli-module-format.test.js
+++ b/packages/massimo-cli/test/cli-module-format.test.js
@@ -33,7 +33,7 @@ test('module format - no package.json (defaults to ESM)', async t => {
 
   const files = await fs.readdir(join(dir, 'movies'))
   deepEqual(files.sort(), [
-    'movies.d.mts',
+    'movies.d.ts',
     'movies.mjs',
     'movies.schema.graphql',
     'package.json'
@@ -45,7 +45,7 @@ test('module format - no package.json (defaults to ESM)', async t => {
   )
   deepEqual(pkg, {
     name: 'movies',
-    types: './movies.d.mts',
+    types: './movies.d.ts',
     type: 'module',
     main: './movies.mjs'
   })
@@ -84,7 +84,7 @@ test('module format - package.json without type field (defaults to CommonJS)', a
   const files = await fs.readdir(join(dir, 'movies'))
   deepEqual(files.sort(), [
     'movies.cjs',
-    'movies.d.cts',
+    'movies.d.ts',
     'movies.schema.graphql',
     'package.json'
   ])
@@ -94,7 +94,7 @@ test('module format - package.json without type field (defaults to CommonJS)', a
   )
   deepEqual(pkg, {
     name: 'movies',
-    types: './movies.d.cts',
+    types: './movies.d.ts',
     main: './movies.cjs'
   })
 })
@@ -135,7 +135,7 @@ test('module format - package.json with type commonjs (generates CommonJS)', asy
   const files = await fs.readdir(join(dir, 'movies'))
   deepEqual(files.sort(), [
     'movies.cjs',
-    'movies.d.cts',
+    'movies.d.ts',
     'movies.schema.graphql',
     'package.json'
   ])
@@ -145,7 +145,7 @@ test('module format - package.json with type commonjs (generates CommonJS)', asy
   )
   deepEqual(pkg, {
     name: 'movies',
-    types: './movies.d.cts',
+    types: './movies.d.ts',
     main: './movies.cjs'
   })
 })

--- a/packages/massimo-cli/test/cli-openapi-additional-properties.test.js
+++ b/packages/massimo-cli/test/cli-openapi-additional-properties.test.js
@@ -17,7 +17,7 @@ test('export formdata on full request object', async t => {
     '--full-request',
     '--full-response'
   ])
-  const typeFile = join(dir, 'additional-props', 'additional-props.d.mts')
+  const typeFile = join(dir, 'additional-props', 'additional-props.d.ts')
   const data = await readFile(typeFile, 'utf-8')
 
   equal(

--- a/packages/massimo-cli/test/cli-openapi-allof-anyof.test.js
+++ b/packages/massimo-cli/test/cli-openapi-allof-anyof.test.js
@@ -18,7 +18,7 @@ test('generate types for allOf/anyOf combinations in body', async () => {
     '--full-response'
   ])
 
-  const typeFile = join(dir, 'fantozzi-types', 'fantozzi-types.d.mts')
+  const typeFile = join(dir, 'fantozzi-types', 'fantozzi-types.d.ts')
   const data = await readFile(typeFile, 'utf-8')
 
   ok(

--- a/packages/massimo-cli/test/cli-openapi-array-req.test.js
+++ b/packages/massimo-cli/test/cli-openapi-array-req.test.js
@@ -25,7 +25,7 @@ test(`${name} with full option`, async () => {
   await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
 
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openapi, '--name', name, '--full'])
-  const typeFile = join(dir, name, `${name}.d.mts`)
+  const typeFile = join(dir, name, `${name}.d.ts`)
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`
@@ -67,7 +67,7 @@ test(`${name} without full option`, async () => {
   await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
 
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openapi, '--name', name, '--full', 'false'])
-  const typeFile = join(dir, name, `${name}.d.mts`)
+  const typeFile = join(dir, name, `${name}.d.ts`)
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`

--- a/packages/massimo-cli/test/cli-openapi-body-string.test.js
+++ b/packages/massimo-cli/test/cli-openapi-body-string.test.js
@@ -25,7 +25,7 @@ test('body-string', async () => {
 
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openapi, '--name', 'full', '--full'])
 
-  const typeFile = join(dir, 'full', 'full.d.mts')
+  const typeFile = join(dir, 'full', 'full.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`

--- a/packages/massimo-cli/test/cli-openapi-empty-req-res.test.js
+++ b/packages/massimo-cli/test/cli-openapi-empty-req-res.test.js
@@ -34,7 +34,7 @@ test('empty-req-res', async () => {
     '--full'
   ])
 
-  const typeFile = join(dir, 'full', 'full.d.mts')
+  const typeFile = join(dir, 'full', 'full.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`

--- a/packages/massimo-cli/test/cli-openapi-full-request-body.test.js
+++ b/packages/massimo-cli/test/cli-openapi-full-request-body.test.js
@@ -34,7 +34,7 @@ test('full-request-body', async t => {
     '--full'
   ])
 
-  const typeFile = join(dir, 'full', 'full.d.mts')
+  const typeFile = join(dir, 'full', 'full.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`

--- a/packages/massimo-cli/test/cli-openapi-no-implementation.test.js
+++ b/packages/massimo-cli/test/cli-openapi-no-implementation.test.js
@@ -20,10 +20,10 @@ test('generates only types in target folder with --types-only flag', async t => 
   ])
   const files = await fs.readdir(dir)
   same(files.length, 1)
-  same(files[0], 'movies.d.mts')
+  same(files[0], 'movies.d.ts')
 
   // avoid name clash
-  const fileContents = await fs.readFile(join(dir, 'movies.d.mts'), 'utf-8')
+  const fileContents = await fs.readFile(join(dir, 'movies.d.ts'), 'utf-8')
   match(fileContents, /export interface FullResponse<T, U extends number> {/)
   match(fileContents, /'statusCode': U;/)
   match(fileContents, /'headers': Record<string, string>;/)
@@ -49,7 +49,7 @@ test('add an initial comment with --types-comment flag', async t => {
     'this is an auto-generated file'
   ])
 
-  const fileContents = await fs.readFile(join(dir, 'movies.d.mts'), 'utf-8')
+  const fileContents = await fs.readFile(join(dir, 'movies.d.ts'), 'utf-8')
   ok(fileContents.startsWith('// this is an auto-generated file'))
 })
 

--- a/packages/massimo-cli/test/cli-openapi-nullable-properties.test.js
+++ b/packages/massimo-cli/test/cli-openapi-nullable-properties.test.js
@@ -17,7 +17,7 @@ test('generate types with nullable properties', async t => {
     '--full-request',
     '--full-response'
   ])
-  const typeFile = join(dir, 'nullable-props', 'nullable-props.d.mts')
+  const typeFile = join(dir, 'nullable-props', 'nullable-props.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`

--- a/packages/massimo-cli/test/cli-openapi-optional-body.test.js
+++ b/packages/massimo-cli/test/cli-openapi-optional-body.test.js
@@ -34,7 +34,7 @@ test(testName, async t => {
     '--props-optional'
   ])
 
-  const typeFile = join(dir, testName, `${testName}.d.mts`)
+  const typeFile = join(dir, testName, `${testName}.d.ts`)
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`
@@ -51,7 +51,7 @@ export type PostHelloRequest = {
   // Checking default behavior
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openapi, '--name', 'defaulted', '--full'])
   equal(
-    (await readFile(join(dir, 'defaulted', 'defaulted.d.mts'), 'utf-8')).includes(`
+    (await readFile(join(dir, 'defaulted', 'defaulted.d.ts'), 'utf-8')).includes(`
 export type PostHelloRequest = {
   body: {
     'name': string;

--- a/packages/massimo-cli/test/cli-openapi-retry-request.test.js
+++ b/packages/massimo-cli/test/cli-openapi-retry-request.test.js
@@ -53,9 +53,9 @@ test('retry-request', async () => {
   ])
 
   ok(await isFileAccessible(join(dir, 'full', 'full.mjs')), 'Implementation file should be created')
-  ok(await isFileAccessible(join(dir, 'full', 'full.d.mts')), 'Type definition file should be created')
+  ok(await isFileAccessible(join(dir, 'full', 'full.d.ts')), 'Type definition file should be created')
 
-  const typeFile = join(dir, 'full', 'full.d.mts')
+  const typeFile = join(dir, 'full', 'full.d.ts')
   const data = await readFile(typeFile, 'utf-8')
 
   ok(data.includes('export type GetRetryRequest ='), 'Should contain GetRetryRequest type')

--- a/packages/massimo-cli/test/cli-openapi-status-code-204.test.js
+++ b/packages/massimo-cli/test/cli-openapi-status-code-204.test.js
@@ -29,7 +29,7 @@ test(name, async () => {
 
   equal(await isFileAccessible(join(dir, name, name + '.js')), false)
 
-  const typeDef = join(dir, name, name + '-types.d.mts')
+  const typeDef = join(dir, name, name + '-types.d.ts')
   const def = await readFile(typeDef, 'utf-8')
   ok(def.includes(`export type PutMartelloRequest = {
   

--- a/packages/massimo-cli/test/cli-openapi-status-codes-range.test.js
+++ b/packages/massimo-cli/test/cli-openapi-status-codes-range.test.js
@@ -34,7 +34,7 @@ test('status-codes-range', async () => {
     '--full'
   ])
 
-  const typeFile = join(dir, 'full', 'full.d.mts')
+  const typeFile = join(dir, 'full', 'full.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   ok(
     data.includes(

--- a/packages/massimo-cli/test/cli-openapi.test.js
+++ b/packages/massimo-cli/test/cli-openapi.test.js
@@ -1014,7 +1014,7 @@ test('optional-headers option', async t => {
     'false'
   ])
 
-  const typeFile = join(dir, 'movies', 'movies.d.mts')
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`

--- a/packages/massimo-cli/test/cli-openapi.test.js
+++ b/packages/massimo-cli/test/cli-openapi.test.js
@@ -110,7 +110,8 @@ test('openapi client generation (typescript)', async t => {
     '--name',
     'movies',
     '--full',
-    'false'
+    'false',
+    '--type-extension'
   ])
 
   const toWrite = `
@@ -585,7 +586,7 @@ test('name with dashes', async t => {
     const pkg = JSON.parse(await fs.readFile(join(dir, 'uncanny-movies', 'package.json'), 'utf-8'))
     same(pkg, {
       name: 'uncanny-movies',
-      types: './uncanny-movies.d.mts',
+      types: './uncanny-movies.d.ts',
       type: 'module',
       main: './uncanny-movies.mjs'
     })
@@ -652,7 +653,8 @@ test('no dashes typescript', async t => {
     '--name',
     'uncanny-movies',
     '--full',
-    'false'
+    'false',
+    '--type-extension'
   ])
 
   const toWrite = `
@@ -751,7 +753,7 @@ test('name with tilde', async t => {
     const pkg = JSON.parse(await fs.readFile(join(dir, 'uncanny~movies', 'package.json'), 'utf-8'))
     same(pkg, {
       name: 'uncanny~movies',
-      types: './uncanny~movies.d.mts',
+      types: './uncanny~movies.d.ts',
       type: 'module',
       main: './uncanny~movies.mjs'
     })
@@ -813,7 +815,7 @@ test('openapi client generation from YAML file', async t => {
   same(json.openapi, '3.0.3')
 
   // Check operation names are correctly capitalized
-  const typeFile = join(dir, 'movies', 'movies.d.mts')
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
   const typeData = await readFile(typeFile, 'utf-8')
 
   equal(match(typeData, 'getMovies(req: GetMoviesRequest): Promise<GetMoviesResponses>;'), true)
@@ -825,7 +827,7 @@ test('nested optional parameters are correctly identified', async t => {
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openapiFile, '--name', 'movies', '--full', 'false'])
 
   // check the type file has the correct implementation for the request
-  const typeFile = join(dir, 'movies', 'movies.d.mts')
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
   const data = await readFile(typeFile, 'utf-8')
 
   equal(
@@ -841,7 +843,7 @@ test('request with same parameter name in body/path/header/query', async t => {
   const openapiFile = join(import.meta.dirname, 'fixtures', 'same-parameter-name-openapi.json')
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openapiFile, '--name', 'movies', '--full', 'false'])
   // check the type file has the correct implementation for the request
-  const typeFile = join(dir, 'movies', 'movies.d.mts')
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`
@@ -881,7 +883,7 @@ test('openapi client generation (javascript) from file with fullRequest, fullRes
     ])
 
     // check the type file has the correct implementation for the request and the response
-    const typeFile = join(dir, 'full', 'full.d.mts')
+    const typeFile = join(dir, 'full', 'full.d.ts')
     const data = await readFile(typeFile, 'utf-8')
     equal(
       data.includes(`
@@ -966,7 +968,7 @@ test('do not generate implementation file if in @platformatic/service', async t 
     ])
 
     // check the type file has the correct implementation for the request and the response
-    const typeFile = join(dir, 'full', 'full.d.mts')
+    const typeFile = join(dir, 'full', 'full.d.ts')
     const data = await readFile(typeFile, 'utf-8')
     equal(
       data.includes(`
@@ -1032,7 +1034,7 @@ test('common parameters in paths', async t => {
   const openAPIfile = join(import.meta.dirname, 'fixtures', 'common-parameters', 'openapi.json')
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openAPIfile, '--name', 'movies', '--full-request'])
 
-  const typeFile = join(dir, 'movies', 'movies.d.mts')
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`
@@ -1164,7 +1166,7 @@ test('requestbody as array', async t => {
 
   const openAPIfile = join(import.meta.dirname, 'fixtures', 'requestbody-as-array-openapi.json')
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openAPIfile, '--name', 'movies', '--full', 'false'])
-  const typeFile = join(dir, 'movies', 'movies.d.mts')
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
   const data = await readFile(typeFile, 'utf-8')
 
   equal(
@@ -1188,7 +1190,7 @@ test('requestBody and params should generate a full request', async t => {
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openapiFile, '--name', 'movies', '--full', 'false'])
 
   // check the type file has the correct implementation for the request
-  const typeFile = join(dir, 'movies', 'movies.d.mts')
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`
@@ -1206,7 +1208,7 @@ test('support formdata', async t => {
 
   const openAPIfile = join(import.meta.dirname, 'fixtures', 'multipart-formdata-openapi.json')
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openAPIfile, '--name', 'movies', '--full', 'false'])
-  const typeFile = join(dir, 'movies', 'movies.d.mts')
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(
     data.includes(`
@@ -1234,7 +1236,7 @@ test('export formdata on full request object', async t => {
 
   const openAPIfile = join(import.meta.dirname, 'fixtures', 'multipart-formdata-openapi.json')
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openAPIfile, '--name', 'movies', '--full-request'])
-  const typeFile = join(dir, 'movies', 'movies.d.mts')
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(data.includes("import { type FormData } from 'undici"), true)
   equal(
@@ -1252,7 +1254,7 @@ test('client with watt.json and skipConfigUpdate', async t => {
   const openAPIfile = join(import.meta.dirname, 'fixtures', 'client-with-config', 'openapi.json')
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openAPIfile, '--name', 'client', '--full-request'])
 
-  const data = await readFile(join(dir, 'client', 'client.d.mts'), 'utf-8')
+  const data = await readFile(join(dir, 'client', 'client.d.ts'), 'utf-8')
   ok(data.includes("import { type FormData } from 'undici"))
 
   const wattConfig = JSON.parse(
@@ -1268,7 +1270,7 @@ test('tsdoc client operation descriptions', async t => {
   const openAPIfile = join(import.meta.dirname, 'fixtures', 'tsdoc-openapi.json')
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openAPIfile, '--name', 'tsdoc', '--full', 'false'])
 
-  const data = await readFile(join(dir, 'tsdoc', 'tsdoc.d.mts'), 'utf-8')
+  const data = await readFile(join(dir, 'tsdoc', 'tsdoc.d.ts'), 'utf-8')
 
   // Description and summary on method
   ok(
@@ -1324,7 +1326,7 @@ test('tsdoc client request option descriptions', async t => {
   const openAPIfile = join(import.meta.dirname, 'fixtures', 'tsdoc-openapi.json')
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openAPIfile, '--name', 'tsdoc', '--full', 'false'])
 
-  const data = await readFile(join(dir, 'tsdoc', 'tsdoc.d.mts'), 'utf-8')
+  const data = await readFile(join(dir, 'tsdoc', 'tsdoc.d.ts'), 'utf-8')
 
   // Description on title, not on id, built from requestBody scheme #ref
   ok(
@@ -1392,7 +1394,7 @@ test('tsdoc client request option descriptions (full-request)', async t => {
   const openAPIfile = join(import.meta.dirname, 'fixtures', 'tsdoc-openapi.json')
   await execa('node', [join(import.meta.dirname, '..', 'index.js'), openAPIfile, '--name', 'tsdoc', '--full-request'])
 
-  const data = await readFile(join(dir, 'tsdoc', 'tsdoc.d.mts'), 'utf-8')
+  const data = await readFile(join(dir, 'tsdoc', 'tsdoc.d.ts'), 'utf-8')
 
   // Descriptions from mixed parameters and requestBody schema #ref
   ok(

--- a/packages/massimo-cli/test/frontend-openapi.test.js
+++ b/packages/massimo-cli/test/frontend-openapi.test.js
@@ -122,10 +122,10 @@ export default function build(url: string, options?: BuildOptions): Platformatic
     const dir = await moveToTmpdir(after)
     await execa('node', [cliPath, `${app.url}/custom-swagger`, '--frontend', '--name', 'sample'])
     const implementation = await readFile(join(dir, 'sample', 'sample.mjs'), 'utf8')
-    const types = await readFile(join(dir, 'sample', 'sample-types.d.mts'), 'utf8')
+    const types = await readFile(join(dir, 'sample', 'sample-types.d.ts'), 'utf8')
 
     const jsImplementationTemplate = `
-/**  @type {import('./sample-types.d.mts').Sample['getCustomSwagger']} */
+/**  @type {import('./sample-types.d.ts').Sample['getCustomSwagger']} */
 export const getCustomSwagger = async (request) => {
   return await _getCustomSwagger(baseUrl, request)
 }`
@@ -190,26 +190,26 @@ test('generate correct file names', async t => {
   // Without --name will create api/client filenames
   await execa('node', [cliPath, app.url, '--language', 'ts', '--frontend'])
   ok(await readFile(join(dir, 'api', 'api.mts'), 'utf-8'))
-  ok(await readFile(join(dir, 'api', 'api-types.d.mts'), 'utf-8'))
+  ok(await readFile(join(dir, 'api', 'api-types.d.ts'), 'utf-8'))
 
   await execa('node', [cliPath, app.url])
   ok(await readFile(join(dir, 'client', 'client.mjs'), 'utf-8'))
-  ok(await readFile(join(dir, 'client', 'client.d.mts'), 'utf-8'))
+  ok(await readFile(join(dir, 'client', 'client.d.ts'), 'utf-8'))
 
-  // With --name will create foobar.ts and foobar-types.d.mts
+  // With --name will create foobar.ts and foobar-types.d.ts
   await execa('node', [cliPath, app.url, '--language', 'ts', '--name', 'foobar', '--frontend'])
   ok(await readFile(join(dir, 'foobar', 'foobar.mts'), 'utf-8'))
-  ok(await readFile(join(dir, 'foobar', 'foobar-types.d.mts'), 'utf-8'))
+  ok(await readFile(join(dir, 'foobar', 'foobar-types.d.ts'), 'utf-8'))
 
-  // Without --name will create api.ts and api-types.d.mts
+  // Without --name will create api.ts and api-types.d.ts
   await execa('node', [cliPath, app.url, '--language', 'ts', '--frontend'])
   ok(await readFile(join(dir, 'api', 'api.mts'), 'utf-8'))
-  ok(await readFile(join(dir, 'api', 'api-types.d.mts'), 'utf-8'))
+  ok(await readFile(join(dir, 'api', 'api-types.d.ts'), 'utf-8'))
 
   // Convert dashes to camelCase
   await execa('node', [cliPath, app.url, '--language', 'ts', '--name', 'sample-name', '--frontend'])
   ok(await readFile(join(dir, 'sample-name', 'sample-name.mts'), 'utf-8'))
-  ok(await readFile(join(dir, 'sample-name', 'sample-name-types.d.mts'), 'utf-8'))
+  ok(await readFile(join(dir, 'sample-name', 'sample-name-types.d.ts'), 'utf-8'))
 })
 
 test('test factory and client', async t => {
@@ -266,7 +266,7 @@ test('generate frontend client from path', async t => {
   const fileName = join(import.meta.dirname, 'fixtures', 'frontend-openapi.json')
   await execa('node', [cliPath, fileName, '--language', 'ts', '--frontend'])
   const implementation = await readFile(join(dir, 'api', 'api.mts'), 'utf8')
-  const types = await readFile(join(dir, 'api', 'api-types.d.mts'), 'utf8')
+  const types = await readFile(join(dir, 'api', 'api-types.d.ts'), 'utf8')
 
   const tsImplementationTemplate = `
 export const getHello: Api['getHello'] = async (request: Types.GetHelloRequest): Promise<Types.GetHelloResponses> => {
@@ -296,7 +296,7 @@ test('generate frontend client from path (name with dashes)', async t => {
   const fileName = join(import.meta.dirname, 'fixtures', 'frontend-openapi.json')
   await execa('node', [cliPath, fileName, '--language', 'ts', '--frontend', '--name', 'a-custom-name'])
   const implementation = await readFile(join(dir, 'a-custom-name', 'a-custom-name.mts'), 'utf8')
-  const types = await readFile(join(dir, 'a-custom-name', 'a-custom-name-types.d.mts'), 'utf8')
+  const types = await readFile(join(dir, 'a-custom-name', 'a-custom-name-types.d.ts'), 'utf8')
   const typePlatformaticFrontendClient = types
     .split('\n')
     .find(line => line.startsWith("type PlatformaticFrontendClient = Omit<ACustomName, 'setBaseUrl'>"))
@@ -541,7 +541,7 @@ test('support empty response', async t => {
     true
   )
 
-  const typeFile = join(dir, 'movies', 'movies-types.d.mts')
+  const typeFile = join(dir, 'movies', 'movies-types.d.ts')
   const type = await readFile(typeFile, 'utf-8')
   equal(
     type.includes(`
@@ -1320,7 +1320,7 @@ import type * as Types from './client-types'`)
 }`)
   )
 
-  const types = await readFile(join(dir, 'client', 'client-types.d.mts'), 'utf-8')
+  const types = await readFile(join(dir, 'client', 'client-types.d.ts'), 'utf-8')
   ok(
     types.includes(`export type GetHelloResponses =
   GetHelloResponseOK`)
@@ -1383,7 +1383,7 @@ test('frontend client with full option', async t => {
   )
   ok(implementation.includes('body: isFormData ? body : JSON.stringify(body),'))
 
-  const types = await readFile(join(dir, 'full-opt', 'full-opt-types.d.mts'), 'utf-8')
+  const types = await readFile(join(dir, 'full-opt', 'full-opt-types.d.ts'), 'utf-8')
   ok(
     types.includes(`export type PostHelloRequest = {
   body: {


### PR DESCRIPTION
#### **Type Extension Determination Rules**

1. **When `--type-extension` is specified**:
   - Always generates module-specific extensions
   - ESM format → `.d.mts`
   - CommonJS format → `.d.cts`

2. **When `--type-extension` is NOT specified**:
   - If `--module` flag is provided:
     - Compares the specified module format with the parent package.json type
     - If they match → generates `.d.ts` (universal compatibility)
     - If they differ → generates module-specific extension (`.d.mts` or `.d.cts`)
   - If no `--module` flag is provided:
     - Always generates `.d.ts` for maximum compatibility

3. **Parent Package.json Detection**:
   - Searches up the directory tree from the output location
   - Stops at the first package.json found
   - ESM parent: `"type": "module"`
   - CommonJS parent: no `type` field or `"type": "commonjs"`

Doc changed here: https://github.com/platformatic/massimo-docs/pull/15