### PR TITLE
feat(props): flip options

### DIFF
--- a/packages/massimo-cli/index.js
+++ b/packages/massimo-cli/index.js
@@ -687,7 +687,9 @@ export async function command (argv) {
     default: {
       typescript: false,
       language: 'js',
-      full: true
+      full: true,
+      'props-optional': true,
+      'skip-config-update': true
     },
     alias: {
       n: 'name',
@@ -729,7 +731,7 @@ export async function command (argv) {
 
     options.fullRequest = options['full-request']
     options.fullResponse = options['full-response']
-    options.propsOptional = options['props-optional'] ?? true
+    options.propsOptional = options['props-optional']
 
     options.optionalHeaders = options['optional-headers']
       ? options['optional-headers'].split(',').map((h) => h.trim())
@@ -748,7 +750,7 @@ export async function command (argv) {
     options.urlAuthHeaders = options['url-auth-headers']
     options.typesComment = options['types-comment']
     options.withCredentials = options['with-credentials']
-    options.skipConfigUpdate = options['skip-config-update'] ?? true
+    options.skipConfigUpdate = options['skip-config-update']
     options.retryTimeoutMs = options['retry-timeout-ms']
     options.typeExtension = options['type-extension']
     options.explicitModuleFormat = !!options.module

--- a/packages/massimo-cli/test/cli-openapi-optional-body.test.js
+++ b/packages/massimo-cli/test/cli-openapi-optional-body.test.js
@@ -49,7 +49,7 @@ export type PostHelloRequest = {
   )
 
   // Checking default behavior
-  await execa('node', [join(import.meta.dirname, '..', 'index.js'), openapi, '--name', 'defaulted', '--full'])
+  await execa('node', [join(import.meta.dirname, '..', 'index.js'), openapi, '--name', 'defaulted', '--full', '--no-props-optional'])
   equal(
     (await readFile(join(dir, 'defaulted', 'defaulted.d.ts'), 'utf-8')).includes(`
 export type PostHelloRequest = {

--- a/packages/massimo-cli/test/cli-openapi.test.js
+++ b/packages/massimo-cli/test/cli-openapi.test.js
@@ -1225,7 +1225,7 @@ export type Movies = {
   equal(
     data.includes(`
 export type PostSampleRequest = {
-  'data': { 'description'?: string; 'endDate': string | Date; 'startDate': string | Date };
+  'data'?: { 'description'?: string; 'endDate': string | Date; 'startDate': string | Date };
 }`),
     true
   )


### PR DESCRIPTION
- removing the `skipConfigUpdate` (no longer used)
- properly apply [this property flip](https://github.com/platformatic/platformatic/pull/4161) to `props-optional`(since by default, when not passed, it's always defined as `false`)