### PR TITLE
Do not use pnpm cache for releases

### DIFF
--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
       - run: npm install npm -g
       - name: pnpm install
         uses: nick-fields/retry@v3.0.2


### PR DESCRIPTION
Ref: https://github.com/platformatic/platformatic/pull/4784

Removes pnpm dependency caching from the release publishing workflow to avoid reusing a potentially poisoned cache when publishing packages.