### PR TITLE
Add contributor triage templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report a reproducible problem in Massimo
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Description
+
+Describe the problem and the behavior you expected.
+
+## Reproduction
+
+Provide a minimal reproduction or the commands needed to reproduce the issue.
+
+## Environment
+
+- Massimo version:
+- Node.js version:
+- pnpm version:
+- Operating system:
+
+## Additional context
+
+Add relevant logs, generated output, or screenshots. Remove secrets before posting.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Testing
+
+List the commands you ran and any scenarios you verified.
+
+## Checklist
+
+- [ ] I ran the relevant tests with `pnpm test` or the package-specific test command.
+- [ ] I ran `pnpm run lint`.
+- [ ] I updated documentation when behavior changed.
+- [ ] My commits include the required DCO sign-off.


### PR DESCRIPTION
This adds two small contributor triage templates:

- `.github/ISSUE_TEMPLATE/bug_report.md` for reproducible bug reports
- `.github/PULL_REQUEST_TEMPLATE.md` for testing, docs, and DCO reminders

This follows up on #159. I kept the change limited to GitHub templates and did not touch product code.

Verification:

- Reviewed the templates locally
- Ran `oss-signal` locally before and after; the maintainer-readiness score improved from 64 to 68 for this repository clone
