### PR TITLE
fix: generate correct TS type for array-form `type` (OpenAPI 3.1 nullable)

### DIFF
--- a/packages/massimo-cli/lib/get-type.js
+++ b/packages/massimo-cli/lib/get-type.js
@@ -60,6 +60,14 @@ export function getType (typeDef, methodType, spec) {
       })
       .join(' & ')
   }
+  if (Array.isArray(typeDef.type)) {
+    // OpenAPI 3.1 / JSON Schema 2020-12 nullable syntax, e.g. `type: ['string', 'null']`.
+    // Resolve each member type independently and join them as a union.
+    const mapped = typeDef.type.map(t => {
+      return getType({ ...typeDef, type: t }, methodType, spec)
+    })
+    return [...new Set(mapped)].join(' | ')
+  }
   if (typeDef.type === 'array') {
     const nullable = typeDef.nullable
     return `Array<${getType(typeDef.items, methodType, spec)}>${nullable === true ? ' | null' : ''}`

--- a/packages/massimo-cli/test/get-type.test.js
+++ b/packages/massimo-cli/test/get-type.test.js
@@ -353,3 +353,47 @@ test('support type nullable null', async () => {
   }
   equal(getType(def), 'null')
 })
+
+test('support array type with string and null (OpenAPI 3.1 nullable syntax)', async () => {
+  const def = {
+    type: ['string', 'null'],
+    maxLength: 255
+  }
+  equal(getType(def), 'string | null')
+})
+
+test('support array type with number and null', async () => {
+  const def = {
+    type: ['number', 'null']
+  }
+  equal(getType(def), 'number | null')
+})
+
+test('support array type inside object properties', async () => {
+  const def = {
+    type: 'object',
+    properties: {
+      description: { type: ['string', 'null'] }
+    },
+    required: ['description']
+  }
+  equal(getType(def), '{ \'description\': string | null }')
+})
+
+test('support array type with object and null', async () => {
+  const def = {
+    type: ['object', 'null'],
+    properties: {
+      foo: { type: 'string' }
+    }
+  }
+  equal(getType(def), '{ \'foo\'?: string } | null')
+})
+
+test('support array type with array and null', async () => {
+  const def = {
+    type: ['array', 'null'],
+    items: { type: 'string' }
+  }
+  equal(getType(def), 'Array<string> | null')
+})


### PR DESCRIPTION
Fixes #170.

Added a control that detects `Array.isArray(typeDef.type)` and resolves each member type independently through `getType()`, joining the results as a union. This handles the common `['string', 'null']` case as well as `['object', 'null']` and `['array', 'null']`, since each member is routed through the existing per-type logic.

**Before:** `'description'?: unknown`
**After:** `'description'?: string | null`