### PR TITLE
fix(massimo-cli): declare frontend setter exports in generated types

### DIFF
--- a/packages/massimo-cli/lib/frontend-openapi-generator.js
+++ b/packages/massimo-cli/lib/frontend-openapi-generator.js
@@ -446,6 +446,12 @@ function generateTypesFromOpenAPI ({ schema, name, fullRequest, fullResponse, pr
     })
   })
 
+  // Declare the module-level named exports emitted by the implementation file,
+  // so consumers relying on the .d.ts can `import { setBaseUrl, ... }` without type errors.
+  writer.writeLine(`export declare const setBaseUrl: ${camelCaseName}['setBaseUrl'];`)
+  writer.writeLine(`export declare const setDefaultHeaders: ${camelCaseName}['setDefaultHeaders'];`)
+  writer.writeLine(`export declare const setDefaultFetchParams: ${camelCaseName}['setDefaultFetchParams'];`)
+
   writer.writeLine(`type PlatformaticFrontendClient = Omit<${camelCaseName}, 'setBaseUrl'>`)
   writer.write('type BuildOptions = ').block(() => {
     writer.writeLine('headers?: object')

--- a/packages/massimo-cli/test/cli-openapi-status-code-204.test.js
+++ b/packages/massimo-cli/test/cli-openapi-status-code-204.test.js
@@ -57,6 +57,9 @@ export interface StatusCode204 {
    */
   putMartello(req: PutMartelloRequest): Promise<PutMartelloResponses>;
 }
+export declare const setBaseUrl: StatusCode204['setBaseUrl'];
+export declare const setDefaultHeaders: StatusCode204['setDefaultHeaders'];
+export declare const setDefaultFetchParams: StatusCode204['setDefaultFetchParams'];
 type PlatformaticFrontendClient = Omit<StatusCode204, 'setBaseUrl'>
 type BuildOptions = {
   headers?: object

--- a/packages/massimo-cli/test/frontend-openapi.test.js
+++ b/packages/massimo-cli/test/frontend-openapi.test.js
@@ -172,6 +172,9 @@ export default function build (url, options) {
 }`
   // factory type
   const factoryType = `
+export declare const setBaseUrl: Sample['setBaseUrl'];
+export declare const setDefaultHeaders: Sample['setDefaultHeaders'];
+export declare const setDefaultFetchParams: Sample['setDefaultFetchParams'];
 type PlatformaticFrontendClient = Omit<Sample, 'setBaseUrl'>
 type BuildOptions = {
   headers?: object
@@ -351,11 +354,16 @@ export interface Api {
    */
   getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`
+  const moduleExportsTemplate = `
+export declare const setBaseUrl: Api['setBaseUrl'];
+export declare const setDefaultHeaders: Api['setDefaultHeaders'];
+export declare const setDefaultFetchParams: Api['setDefaultFetchParams'];`
 
   ok(implementation)
   ok(types)
   equal(implementation.includes(tsImplementationTemplate), true)
   equal(types.includes(typesTemplate), true)
+  equal(types.includes(moduleExportsTemplate), true)
 })
 
 test('generate frontend client from path (name with dashes)', async t => {
@@ -1404,6 +1412,11 @@ import type * as Types from './client-types'`)
    */
   getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`)
+  )
+  ok(
+    types.includes(`export declare const setBaseUrl: Client['setBaseUrl'];
+export declare const setDefaultHeaders: Client['setDefaultHeaders'];
+export declare const setDefaultFetchParams: Client['setDefaultFetchParams'];`)
   )
   ok(types.includes("type PlatformaticFrontendClient = Omit<Client, 'setBaseUrl'>"))
   ok(types.includes('export default function build(url: string, options?: BuildOptions): PlatformaticFrontendClient'))


### PR DESCRIPTION
# fix(massimo-cli): declare frontend setter exports in generated types

## Problem

For frontend clients (`--frontend`), the generated implementation file exports three module-level functions:

```ts
export const setBaseUrl = (newUrl: string) : void => { baseUrl = sanitizeUrl(newUrl) }
export const setDefaultHeaders = (headers: object): void => { defaultHeaders = headers }
export const setDefaultFetchParams = (fetchParams: RequestInit): void => { defaultFetchParams = fetchParams }
```

but the generated `<name>-types.d.ts` never declares them. They only appear as *methods* on the client interface (`setBaseUrl(newUrl: string): void;` etc.), which does not describe the module's named exports.

Any consumer whose tooling resolves types from the `.d.ts` — for example a package that ships the generated client with a `"types"` field pointing at `<name>-types.d.ts` — gets `TS2305: Module has no exported member 'setDefaultHeaders'` on

```ts
import build, { setDefaultHeaders } from './client'
```

even though the symbol exists at runtime. Until now we have been post-processing the generated `.d.ts` with `sed` to re-add the three declarations after every regeneration.

## Reproduction

```sh
massimo openapi.json --frontend --language ts --name api
```

`api/api.mts` exports `setBaseUrl`, `setDefaultHeaders`, `setDefaultFetchParams`; `api/api-types.d.ts` contains no top-level declaration for any of them. Same for `--language js` (the JSDoc `@type` annotations reference the interface members, but a `.d.ts`-only consumer still sees no named exports).

## Fix

`generateTypesFromOpenAPI` in `packages/massimo-cli/lib/frontend-openapi-generator.js` now emits, right after the client interface:

```ts
export declare const setBaseUrl: Api['setBaseUrl'];
export declare const setDefaultHeaders: Api['setDefaultHeaders'];
export declare const setDefaultFetchParams: Api['setDefaultFetchParams'];
```

The declarations are typed via the interface's own members (same pattern the JS implementation already uses in its JSDoc `@type` annotations), so they can never drift from the interface.

## Tests

- `test/frontend-openapi.test.js`: extended the `factoryType` template in the base test to pin the exact placement of the three declarations, and added explicit assertions in "generate frontend client from path" and in the watt-config test.
- `test/cli-openapi-status-code-204.test.js`: updated the expected `.d.ts` template to the new output.

Full `massimo-cli` suite: **136/136 passing** (`node --test test/*.test.js`), `tsd` and `eslint` clean.
