### PR TITLE
fix(massimo-cli): quote enum members by value type

### DIFF
--- a/packages/massimo-cli/lib/get-type.js
+++ b/packages/massimo-cli/lib/get-type.js
@@ -73,11 +73,10 @@ export function getType (typeDef, methodType, spec) {
     const nullable = typeDef.nullable
     const chainedTypes = typeDef.enum
       .map(en => {
-        if (typeDef.type === 'string') {
-          return `'${en.replace(/'/g, "\\'")}'`
-        } else {
-          return en
-        }
+        // Quote by the runtime type of the value: the schema may omit `type`
+        if (en === null) return 'null'
+        if (typeof en === 'string') return `'${en.replace(/'/g, "\\'")}'`
+        return en
       })
       .join(' | ')
     return nullable === true ? `${chainedTypes} | null` : chainedTypes

--- a/packages/massimo-cli/test/get-type.test.js
+++ b/packages/massimo-cli/test/get-type.test.js
@@ -346,6 +346,21 @@ test('support enum nullable null', async () => {
   equal(getType(def), 'null')
 })
 
+test('support enum without type', async () => {
+  // string members must be quoted even when the schema omits `type`
+  equal(getType({ enum: ['a', 'b'] }), "'a' | 'b'")
+  equal(getType({ enum: [1, 2] }), '1 | 2')
+  equal(getType({ enum: [true, false] }), 'true | false')
+  equal(getType({ enum: ["it's"] }), "'it\\'s'")
+  equal(getType({ enum: ['a', null] }), "'a' | null")
+  equal(getType({ type: 'number', enum: [1, 2] }), '1 | 2')
+  equal(getType({
+    type: 'object',
+    required: ['field'],
+    properties: { field: { enum: ['a', 'b'] } }
+  }), "{ 'field': 'a' | 'b' }")
+})
+
 test('support type nullable null', async () => {
   const def = {
     type: 'null',


### PR DESCRIPTION
Fixes #173

## Problem

`getType()` decided whether to quote enum members from the schema's `type` keyword. `type` is optional in JSON Schema / OpenAPI 3.x — the `enum` already constrains the value — so a spec like

```json
"tone": { "enum": ["informale", "formale", "amichevole"] }
```

fell into the `else` branch and emitted bare identifiers:

```ts
'tone': informale | formale | amichevole;   // TS2304: Cannot find name 'informale'
```

making the generated `index.d.mts` non-compilable. The same enum with `"type": "string"` was generated correctly.

A literal `null` inside an `enum` was also stringified to an empty union member (`'a' | `), another syntax error.

## Change

Quote each member by its own runtime type instead of by the schema `type`:

```js
.map(en => {
  // Quote by the runtime type of the value: the schema may omit `type`
  if (en === null) return 'null'
  if (typeof en === 'string') return `'${en.replace(/'/g, "\\'")}'`
  return en
})
```

The pre-existing early return above it (`type === undefined` + an enum containing the *string* `'null'` → `null`) is left untouched: that is the existing encoding for nullable types and would otherwise start emitting `'null'`.

## Behaviour

| input schema | before | after |
| --- | --- | --- |
| `{ enum: ['a','b'] }` | `a \| b` ❌ | `'a' \| 'b'` |
| `{ type: 'string', enum: ['a','b'] }` | `'a' \| 'b'` | unchanged |
| `{ enum: [1,2] }` | `1 \| 2` | unchanged |
| `{ enum: [true,false] }` | `true \| false` | unchanged |
| `{ enum: ["it's"] }` | `it's` ❌ | `'it\'s'` |
| `{ enum: ['a', null] }` | `'a' \| ` ❌ | `'a' \| null` |

## Tests

Added `support enum without type` to `packages/massimo-cli/test/get-type.test.js`, covering the table above plus an untyped enum nested in an object.

`test/get-type.test.js` passes (21/21), as do `test/cli-openapi*.test.js` and `test/frontend-openapi.test.js` (81/81). Lint is clean.
