### PR TITLE
chore: upgrade pnpm to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,9 +1,0 @@
-package-lock=true
-auto-install-peers=true
-strict-peer-dependencies=false
-child-concurrency=1
-resolution-mode=highest
-prefer-symlinked-executables=true
-node-linker=hoisted
-package-import-method=copy
-hoist=false

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cleanall": "rm pnpm-lock.yaml && rm -rf node_modules && rm -rf packages/*/node_modules",
     "clean": "rm -rf node_modules && rm -rf packages/*/node_modules"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@11.23.0",
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
     "markdownlint-cli2": "^0.23.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,26 @@
 packages:
   - 'packages/*'
+
+autoInstallPeers: true
+strictPeerDependencies: false
+childConcurrency: 1
+resolutionMode: highest
+preferSymlinkedExecutables: true
+nodeLinker: hoisted
+packageImportMethod: copy
+hoist: false
+allowBuilds:
+  '@fastify/pre-commit': true
+  better-sqlite3: true
+  esbuild: true
+  msgpackr-extract: true
+  protobufjs: true
+
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - fastify@5.12.1
+  - find-my-way@9.9.0
+minimumReleaseAgeExcludePrune: true
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 10080
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary

- upgrade the workspace package manager from pnpm 9.15.9 to 11.23.0
- move pnpm settings from `.npmrc` to `pnpm-workspace.yaml`, as pnpm 11 only reads authentication and registry settings from `.npmrc`
- explicitly allow the dependency build scripts required by native/runtime dependencies
- enable a seven-day minimum release age, trust-downgrade checks, and exotic transitive dependency blocking
- retain narrowly pinned release-age exceptions for the reviewed Fastify security update and its router dependency

## Validation

- clean `pnpm@11.23.0 install --frozen-lockfile`, including native dependency builds
- supply-chain policy verification for all 1,036 lockfile entries
- full test suite: 186/186 passing
- Massimo CLI Playwright E2E and TypeScript validation
- workspace lint
- frozen offline lockfile validation
