### PR TITLE
fix(get-type): detect reference cycles and turn them into unknown

### DIFF
--- a/packages/massimo-cli/lib/get-type.js
+++ b/packages/massimo-cli/lib/get-type.js
@@ -1,16 +1,21 @@
 import jsonpointer from 'jsonpointer'
 
-export function getType (typeDef, methodType, spec) {
+export function getType (typeDef, methodType, spec, seenRefs = new Set()) {
   if (typeDef.$ref) {
+    if (seenRefs.has(typeDef.$ref)) {
+      return 'unknown'
+    }
+    seenRefs = new Set(seenRefs)
+    seenRefs.add(typeDef.$ref)
     typeDef = jsonpointer.get(spec, typeDef.$ref.replace('#', ''))
   }
   if (typeDef.schema) {
-    return getType(typeDef.schema, methodType, spec)
+    return getType(typeDef.schema, methodType, spec, seenRefs)
   }
   if (typeDef.anyOf) {
     // recursively call this function
     const mapped = typeDef.anyOf.map(t => {
-      return getType(t, methodType, spec)
+      return getType(t, methodType, spec, seenRefs)
     })
     return mapped.join(' | ')
   }
@@ -18,7 +23,7 @@ export function getType (typeDef, methodType, spec) {
   if (typeDef.oneOf) {
     // recursively call this function
     const mapped = typeDef.oneOf.map(t => {
-      return getType(t, methodType, spec)
+      return getType(t, methodType, spec, seenRefs)
     })
 
     if (typeDef.discriminator && typeDef.discriminator.propertyName) {
@@ -56,13 +61,13 @@ export function getType (typeDef, methodType, spec) {
     // recursively call this function
     return typeDef.allOf
       .map(t => {
-        return getType(t, methodType, spec)
+        return getType(t, methodType, spec, seenRefs)
       })
       .join(' & ')
   }
   if (typeDef.type === 'array') {
     const nullable = typeDef.nullable
-    return `Array<${getType(typeDef.items, methodType, spec)}>${nullable === true ? ' | null' : ''}`
+    return `Array<${getType(typeDef.items, methodType, spec, seenRefs)}>${nullable === true ? ' | null' : ''}`
   }
   if (typeDef.enum) {
     // Note: null type represented with an enum have no types and single enum element 'null'
@@ -107,7 +112,7 @@ export function getType (typeDef, methodType, spec) {
       if (additionalPropsRequired) {
         required = required || !!additionalPropsRequired.includes(prop)
       }
-      return `'${prop}'${required ? '' : '?'}: ${getType(objProperties[prop], methodType, spec)}`
+      return `'${prop}'${required ? '' : '?'}: ${getType(objProperties[prop], methodType, spec, seenRefs)}`
     })
     if (additionalProps === true) {
       props.push('[key: string]: unknown')

--- a/packages/massimo-cli/test/get-type.test.js
+++ b/packages/massimo-cli/test/get-type.test.js
@@ -368,3 +368,64 @@ test('support type nullable null', async () => {
   }
   equal(getType(def), 'null')
 })
+
+test('support direct self-reference without infinite recursion', async () => {
+  const spec = {
+    components: {
+      schemas: {
+        Node: {
+          type: 'object',
+          properties: {
+            children: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/Node' }
+            }
+          }
+        }
+      }
+    }
+  }
+  const type = getType({ $ref: '#/components/schemas/Node' }, 'res', spec)
+  equal(type, "{ 'children'?: Array<unknown> }")
+})
+
+test('support mutual recursion between two components without infinite recursion', async () => {
+  const spec = {
+    components: {
+      schemas: {
+        A: {
+          type: 'object',
+          properties: { b: { $ref: '#/components/schemas/B' } }
+        },
+        B: {
+          type: 'object',
+          properties: { a: { $ref: '#/components/schemas/A' } }
+        }
+      }
+    }
+  }
+  const type = getType({ $ref: '#/components/schemas/A' }, 'res', spec)
+  equal(type, "{ 'b'?: { 'a'?: unknown } }")
+})
+
+test('sibling properties referencing the same non-cyclic component both expand fully', async () => {
+  const spec = {
+    components: {
+      schemas: {
+        Shared: {
+          type: 'object',
+          properties: { value: { type: 'string' } }
+        },
+        Parent: {
+          type: 'object',
+          properties: {
+            first: { $ref: '#/components/schemas/Shared' },
+            second: { $ref: '#/components/schemas/Shared' }
+          }
+        }
+      }
+    }
+  }
+  const type = getType({ $ref: '#/components/schemas/Parent' }, 'res', spec)
+  equal(type, "{ 'first'?: { 'value'?: string }; 'second'?: { 'value'?: string } }")
+})


### PR DESCRIPTION
Currently Massimo has no way of detecting cycles in openapi definitions.

If there is a cycle it exhausts the stack by recursing indefinitely.

This PR adds a simple set to the `getType` recursion, to keep track of already visited references to detect cycles, returning the `unknown` type when one is detected.

While we lose type accuracy by doing it this way, at least it allows to work with cyclic definitions.